### PR TITLE
fix font-bold settings

### DIFF
--- a/util/common/image-block/style/style.css
+++ b/util/common/image-block/style/style.css
@@ -115,6 +115,7 @@ by Ambersight
 }
  
 .scp-image-caption p {
+    --wght: 700;
     font-size: 0.8rem;
     font-weight: 700;
 }


### PR DESCRIPTION
font-bold の設定が 旧 image-block のクラス名にのみ指定されてなかったので、治しました